### PR TITLE
Fixing a bug that prevented contributors from running from source

### DIFF
--- a/killua/bot.py
+++ b/killua/bot.py
@@ -96,7 +96,7 @@ class BaseBot(commands.AutoShardedBot):
             entitlement async for entitlement in self.entitlements(limit=None)
         ]
         if (await DB.const.find_one({"_id": "migrate"}))["value"]:
-            migrate_requiring_bot(self)
+            await migrate_requiring_bot(self)
             await DB.const.update_one({"_id": "migrate"}, {"$set": {"value": False}})
 
     async def _turn_top_level_user_installed(self, command: commands.HybridCommand):

--- a/killua/migrate.py
+++ b/killua/migrate.py
@@ -17,7 +17,7 @@ async def migrate_requiring_bot(bot: Type[AutoShardedBot]):
     logging.info("Migrating database...")
     const: Collection = DB._DB["const"]
 
-    usage: dict = await const.find_one({"_id": "usage"})["command_usage"]
+    usage: dict = await (const.find_one({"_id": "usage"}))["command_usage"]
 
     logging.info("Attemping to migrate edge cases...")
     usage["games gstats"] = usage.get("games stats", 0)

--- a/killua/migrate.py
+++ b/killua/migrate.py
@@ -17,7 +17,7 @@ async def migrate_requiring_bot(bot: Type[AutoShardedBot]):
     logging.info("Migrating database...")
     const: Collection = DB._DB["const"]
 
-    usage: dict = await (const.find_one({"_id": "usage"}))["command_usage"]
+    usage: dict = (await const.find_one({"_id": "usage"}))["command_usage"]
 
     logging.info("Attemping to migrate edge cases...")
     usage["games gstats"] = usage.get("games stats", 0)

--- a/killua/migrate.py
+++ b/killua/migrate.py
@@ -10,14 +10,14 @@ from discord.ext.commands import AutoShardedBot, HybridGroup
 from killua.static.constants import DB
 
 
-def migrate_requiring_bot(bot: Type[AutoShardedBot]):
+async def migrate_requiring_bot(bot: Type[AutoShardedBot]):
     """
     Migrates the database from one version to another, requiring a bot instance. Automatically called when the bot starts if `--migrate` was run before.
     """
     logging.info("Migrating database...")
     const: Collection = DB._DB["const"]
 
-    usage: dict = const.find_one({"_id": "usage"})["command_usage"]
+    usage: dict = await const.find_one({"_id": "usage"})["command_usage"]
 
     logging.info("Attemping to migrate edge cases...")
     usage["games gstats"] = usage.get("games stats", 0)


### PR DESCRIPTION
### What is the pull request for?
Fixed an issue in the migrate.py and bot.py scripts that prevented a user from running the bot from source due to the `migrate_requiring_bot` function not being async, and directly trying to subscript the `const.find_one({"_id": "usage"})`

CHANGED LINE: `usage: dict = await const.find_one({"_id": "usage"})["command_usage"]`
TO
```python
com_usage = await const.find_one({"_id": "usage"})

usage: dict = com_usage["command_usage"]
```


### Please check the boxes if appropriate

- [x] I have tested these changes (when running from source, running from docker using these changes is untested)
- [ ] This PR fixes an open issue
- [ ] This PR adds a new feature
 
### How can we get in touch with you if we need more info?
Discord: fourshadows4